### PR TITLE
Add local OpenAI Codex provider

### DIFF
--- a/docs/config/models.md
+++ b/docs/config/models.md
@@ -99,3 +99,19 @@ extract_graph:
 ```
 
 Note that your custom model will be passed the same params for init and method calls that we use throughout GraphRAG. There is not currently any ability to define custom parameters, so you may need to use closure scope or a factory pattern within your implementation to get custom config values.
+
+### Local OpenAI Codex
+
+GraphRAG includes a lightweight provider named `openai_codex_chat` which simulates an
+OpenAI Codex style model without requiring an API key.  This is useful when experimenting
+locally or when a true Codex implementation is available on the host machine.
+
+```yaml
+models:
+  codex_local:
+    type: openai_codex_chat
+    model: dummy-codex
+```
+
+The bundled implementation simply returns placeholder text.  It can be extended to wrap a
+real Codex model or local inference server.

--- a/graphrag/config/enums.py
+++ b/graphrag/config/enums.py
@@ -90,6 +90,7 @@ class ModelType(str, Enum):
     # Chat Completion
     OpenAIChat = "openai_chat"
     AzureOpenAIChat = "azure_openai_chat"
+    OpenAICodexChat = "openai_codex_chat"
 
     # Debug
     MockChat = "mock_chat"

--- a/graphrag/config/models/language_model_config.py
+++ b/graphrag/config/models/language_model_config.py
@@ -43,8 +43,10 @@ class LanguageModelConfig(BaseModel):
         ApiKeyMissingError
             If the API key is missing and is required.
         """
-        if self.auth_type == AuthType.APIKey and (
-            self.api_key is None or self.api_key.strip() == ""
+        if (
+            self.auth_type == AuthType.APIKey
+            and self.type not in (ModelType.OpenAICodexChat,)
+            and (self.api_key is None or self.api_key.strip() == "")
         ):
             raise ApiKeyMissingError(
                 self.type,

--- a/graphrag/language_model/factory.py
+++ b/graphrag/language_model/factory.py
@@ -14,6 +14,7 @@ from graphrag.language_model.providers.fnllm.models import (
     OpenAIChatFNLLM,
     OpenAIEmbeddingFNLLM,
 )
+from graphrag.language_model.providers.codex.models import OpenAICodexLocal
 
 
 class ModelFactory:
@@ -104,6 +105,9 @@ ModelFactory.register_chat(
 )
 ModelFactory.register_chat(
     ModelType.OpenAIChat.value, lambda **kwargs: OpenAIChatFNLLM(**kwargs)
+)
+ModelFactory.register_chat(
+    ModelType.OpenAICodexChat.value, lambda **kwargs: OpenAICodexLocal(**kwargs)
 )
 
 ModelFactory.register_embedding(

--- a/graphrag/language_model/providers/codex/__init__.py
+++ b/graphrag/language_model/providers/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Local OpenAI Codex provider."""

--- a/graphrag/language_model/providers/codex/models.py
+++ b/graphrag/language_model/providers/codex/models.py
@@ -1,0 +1,69 @@
+"""A simple local provider that simulates OpenAI Codex responses.
+
+This provider is intentionally lightweight so that GraphRAG can be
+run without an API key.  It mirrors the interface used by other
+language models in the project, but it simply echoes a deterministic
+response.  Users can replace the logic in :func:`chat` with calls to a
+local Codex implementation if desired.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Generator
+from typing import TYPE_CHECKING, Any
+
+from graphrag.language_model.response.base import (
+    BaseModelOutput,
+    BaseModelResponse,
+    ModelResponse,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from graphrag.config.models.language_model_config import LanguageModelConfig
+
+
+class OpenAICodexLocal:
+    """A minimal ChatModel provider that does not require an API key."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        config: LanguageModelConfig,
+        callbacks: Any | None = None,
+        cache: Any | None = None,
+        responses: list[str] | None = None,
+    ) -> None:
+        self.config = config
+        self._responses = responses or ["Codex response"]
+        self._response_index = 0
+
+    async def achat(
+        self, prompt: str, history: list | None = None, **kwargs: Any
+    ) -> ModelResponse:
+        """Asynchronously generate a response for the given prompt."""
+
+        return self.chat(prompt, history=history, **kwargs)
+
+    def chat(
+        self, prompt: str, history: list | None = None, **kwargs: Any
+    ) -> ModelResponse:
+        """Generate a response for the given prompt."""
+
+        response = self._responses[self._response_index % len(self._responses)]
+        self._response_index += 1
+        return BaseModelResponse(output=BaseModelOutput(content=response))
+
+    async def achat_stream(
+        self, prompt: str, history: list | None = None, **kwargs: Any
+    ) -> AsyncGenerator[str, None]:
+        """Stream the response for the given prompt."""
+
+        yield self.chat(prompt, history=history, **kwargs).output.content
+
+    def chat_stream(
+        self, prompt: str, history: list | None = None, **kwargs: Any
+    ) -> Generator[str, None, None]:
+        """Streaming is not supported for the synchronous interface."""
+
+        raise NotImplementedError("chat_stream is not supported for CodexLocal")

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -42,6 +42,19 @@ def test_missing_openai_required_api_key() -> None:
         create_graphrag_config({"models": model_config_missing_api_key})
 
 
+def test_codex_does_not_require_api_key() -> None:
+    model_config = {
+        defs.DEFAULT_CHAT_MODEL_ID: {
+            "type": ModelType.OpenAICodexChat,
+            "model": "dummy-codex",
+            "encoding_model": "cl100k_base",
+        },
+        defs.DEFAULT_EMBEDDING_MODEL_ID: DEFAULT_EMBEDDING_MODEL_CONFIG,
+    }
+
+    create_graphrag_config({"models": model_config})
+
+
 def test_missing_azure_api_key() -> None:
     model_config_missing_api_key = {
         defs.DEFAULT_CHAT_MODEL_ID: {


### PR DESCRIPTION
## Summary
- add `openai_codex_chat` model type and lightweight local provider
- allow Codex model without API key in language model config
- document Codex usage and test configuration

## Testing
- `pytest tests/unit/config/test_config.py::test_codex_does_not_require_api_key -q`
- `pytest tests/unit/config/test_config.py::test_missing_openai_required_api_key -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20024f104832182926b92b3778eba