### PR TITLE
Handle missing entity types in graph extractor

### DIFF
--- a/graphrag/index/operations/extract_graph/graph_extractor.py
+++ b/graphrag/index/operations/extract_graph/graph_extractor.py
@@ -97,6 +97,10 @@ class GraphExtractor:
         source_doc_map: dict[int, str] = {}
 
         # Wire defaults into the prompt variables
+        entity_types = prompt_variables.get(self._entity_types_key)
+        if not entity_types:
+            entity_types = DEFAULT_ENTITY_TYPES
+
         prompt_variables = {
             **prompt_variables,
             self._tuple_delimiter_key: prompt_variables.get(self._tuple_delimiter_key)
@@ -107,9 +111,7 @@ class GraphExtractor:
                 self._completion_delimiter_key
             )
             or DEFAULT_COMPLETION_DELIMITER,
-            self._entity_types_key: ",".join(
-                prompt_variables[self._entity_types_key] or DEFAULT_ENTITY_TYPES
-            ),
+            self._entity_types_key: ",".join(entity_types),
         }
 
         for doc_index, text in enumerate(texts):

--- a/tests/unit/indexing/verbs/entities/extraction/strategies/graph_intelligence/test_gi_entity_extraction.py
+++ b/tests/unit/indexing/verbs/entities/extraction/strategies/graph_intelligence/test_gi_entity_extraction.py
@@ -2,13 +2,49 @@
 # Licensed under the MIT License
 import unittest
 
+from graphrag.index.operations.extract_graph.graph_extractor import (
+    DEFAULT_ENTITY_TYPES,
+)
 from graphrag.index.operations.extract_graph.graph_intelligence_strategy import (
     run_extract_graph,
 )
 from graphrag.index.operations.extract_graph.typing import (
     Document,
 )
+from graphrag.language_model.response.base import BaseModelOutput, BaseModelResponse
 from tests.unit.indexing.verbs.helpers.mock_llm import create_mock_llm
+
+
+BASIC_GRAPH_RESPONSE = """
+("entity"<|>TEST_ENTITY_1<|>COMPANY<|>TEST_ENTITY_1 is a test company)
+##
+("entity"<|>TEST_ENTITY_2<|>COMPANY<|>TEST_ENTITY_2 is related to TEST_ENTITY_1)
+##
+("relationship"<|>TEST_ENTITY_1<|>TEST_ENTITY_2<|>TEST_ENTITY_1 and TEST_ENTITY_2 are related<|>1))
+""".strip()
+
+
+class RecordingChatModel:
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._response_index = 0
+        self.prompts: list[str] = []
+
+    async def achat(self, prompt: str, history: list | None = None, **kwargs):
+        self.prompts.append(prompt)
+        if self._response_index < len(self._responses):
+            response = self._responses[self._response_index]
+            self._response_index += 1
+        else:
+            response = ""
+
+        new_history = list(history) if history else []
+        new_history.append({"prompt": prompt, "response": response})
+
+        return BaseModelResponse(
+            output=BaseModelOutput(content=response),
+            history=new_history,
+        )
 
 
 class TestRunChain(unittest.IsolatedAsyncioTestCase):
@@ -216,3 +252,37 @@ class TestRunChain(unittest.IsolatedAsyncioTestCase):
         edge_source_ids = sorted([edge[2].get("source_id", "") for edge in edges])
         assert edge_source_ids[0].split(",") == ["1"]
         assert edge_source_ids[1].split(",") == ["2"]
+
+    async def test_run_extract_graph_defaults_entity_types_when_missing(self):
+        model = RecordingChatModel([BASIC_GRAPH_RESPONSE])
+
+        results = await run_extract_graph(
+            docs=[Document("text_1", "1")],
+            entity_types=None,
+            args={
+                "max_gleanings": 0,
+                "summarize_descriptions": False,
+            },
+            model=model,
+        )
+
+        assert results.entities, "Expected entities to be returned"
+        assert model.prompts, "Expected the model to receive at least one prompt"
+        assert f"[{','.join(DEFAULT_ENTITY_TYPES)}]" in model.prompts[0]
+
+    async def test_run_extract_graph_honors_custom_entity_types_override(self):
+        custom_entity_types = ["alpha", "beta"]
+        model = RecordingChatModel([BASIC_GRAPH_RESPONSE])
+
+        await run_extract_graph(
+            docs=[Document("text_1", "1")],
+            entity_types=custom_entity_types,
+            args={
+                "max_gleanings": 0,
+                "summarize_descriptions": False,
+            },
+            model=model,
+        )
+
+        assert model.prompts, "Expected the model to receive at least one prompt"
+        assert f"[{','.join(custom_entity_types)}]" in model.prompts[0]


### PR DESCRIPTION
## Summary
- ensure the graph extractor falls back to the default entity types when the prompt variables omit them
- add a recording chat model test helper and new unit tests that cover default behaviour and explicit overrides for entity types

## Testing
- pytest tests/unit/indexing/verbs/entities/extraction/strategies/graph_intelligence/test_gi_entity_extraction.py


------
https://chatgpt.com/codex/tasks/task_e_68d16837eec483219597242e5a8f840a